### PR TITLE
build: modify ts compiler options

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     },
     "scripts": {
         "prepare": "node ./configure-references.js",
-        "build": "lerna run build --stream",
-        "lint": "lerna run lint --stream --parallel",
-        "test": "lerna run test  --stream",
+        "build": "lerna run build --stream --no-private",
+        "lint": "lerna run lint --stream --parallel --no-private",
+        "test": "lerna run test  --stream --no-private",
         "commit": "git-cz",
         "release": "changeset publish",
         "version": "changeset version"

--- a/packages/layouts/package.json
+++ b/packages/layouts/package.json
@@ -4,6 +4,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "license": "MIT",
+    "private": true,
     "repository": {
         "type": "git",
         "directory": "packages/layouts",

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -4,7 +4,9 @@
         "outDir": "./dist",
         "rootDir": "./src",
         "composite": true,
-        "downlevelIteration": true
+        "downlevelIteration": true,
+        "module": "es6",
+        "moduleResolution": "node"
     },
     "include": ["src/**/*"],
     "references": [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "es5",
         "outDir": "./dist",
-        "module": "es6",
+        "module": "commonjs",
         "moduleResolution": "node",
         "jsx": "react",
         "strict": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "target": "es5",
         "outDir": "./dist",
-        "module": "commonjs",
+        "module": "es6",
+        "moduleResolution": "node",
         "jsx": "react",
         "strict": true,
         "declaration": true,


### PR DESCRIPTION
modified the ts build option to build es6 module for browser support. 
also set layouts package to `private`(it needs more work)

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
Because commonjs uses `require` we are not able to use the module type on `script` tags to import. 

## ⛳️ Current behavior (updates)

We need to use other third-party tools like browserify to add `@type-ethiopic/web` to an html page.  

## 🚀 New behavior

We can now use `@type-ethiopic/web` on html pages using the `module` type on `script` tags.

```html
<script type="module">
    import {TypeEthiopicWeb} from "https://cdn.jsdelivr.net/npm/@type-ethiopic/web";
</script>
```

## 💣 Is this a breaking change (Yes/No):

NO

## 📝 Additional Information
